### PR TITLE
Do not maintain in-memory results when streaming

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -12,13 +12,13 @@ type (
 	providerRecord struct {
 		peer.AddrInfo
 	}
-	acceptor interface {
+	selectiveResponseWriter interface {
+		http.ResponseWriter
 		Accept(r *http.Request) error
 	}
 	lookupResponseWriter interface {
 		io.Closer
-		http.ResponseWriter
-		acceptor
+		selectiveResponseWriter
 		Key() cid.Cid
 		WriteProviderRecord(providerRecord) error
 	}

--- a/response_writer_dr.go
+++ b/response_writer_dr.go
@@ -21,7 +21,7 @@ const drSchemaBitswap = "bitswap"
 
 type (
 	delegatedRoutingLookupResponseWriter struct {
-		jsonAcceptor
+		jsonResponseWriter
 		key    cid.Cid
 		result drProviderRecords
 	}
@@ -38,12 +38,12 @@ type (
 
 func newDelegatedRoutingLookupResponseWriter(w http.ResponseWriter) lookupResponseWriter {
 	return &delegatedRoutingLookupResponseWriter{
-		jsonAcceptor: newJsonAcceptor(w),
+		jsonResponseWriter: newJsonResponseWriter(w),
 	}
 }
 
 func (d *delegatedRoutingLookupResponseWriter) Accept(r *http.Request) error {
-	if err := d.jsonAcceptor.Accept(r); err != nil {
+	if err := d.jsonResponseWriter.Accept(r); err != nil {
 		return err
 	}
 	sc := strings.TrimPrefix(path.Base(r.URL.Path), "routing/v1/providers/")
@@ -77,8 +77,9 @@ func (d *delegatedRoutingLookupResponseWriter) WriteProviderRecord(provider prov
 		if d.f != nil {
 			d.f.Flush()
 		}
+	} else {
+		d.result.Providers = append(d.result.Providers, rec)
 	}
-	d.result.Providers = append(d.result.Providers, rec)
 	return nil
 }
 

--- a/response_writer_ipni.go
+++ b/response_writer_ipni.go
@@ -14,7 +14,7 @@ var _ lookupResponseWriter = (*ipniLookupResponseWriter)(nil)
 
 type (
 	ipniLookupResponseWriter struct {
-		jsonAcceptor
+		jsonResponseWriter
 		result MultihashResult
 		count  int
 	}
@@ -34,12 +34,12 @@ type (
 
 func newIPNILookupResponseWriter(w http.ResponseWriter) lookupResponseWriter {
 	return &ipniLookupResponseWriter{
-		jsonAcceptor: newJsonAcceptor(w),
+		jsonResponseWriter: newJsonResponseWriter(w),
 	}
 }
 
 func (i *ipniLookupResponseWriter) Accept(r *http.Request) error {
-	if err := i.jsonAcceptor.Accept(r); err != nil {
+	if err := i.jsonResponseWriter.Accept(r); err != nil {
 		return err
 	}
 	smh := strings.TrimPrefix(path.Base(r.URL.Path), "multihash/")
@@ -81,8 +81,9 @@ func (i *ipniLookupResponseWriter) WriteProviderRecord(provider providerRecord) 
 			i.f.Flush()
 		}
 		i.count++
+	} else {
+		i.result.ProviderResults = append(i.result.ProviderResults, rec)
 	}
-	i.result.ProviderResults = append(i.result.ProviderResults, rec)
 	return nil
 }
 

--- a/response_writer_json.go
+++ b/response_writer_json.go
@@ -13,25 +13,25 @@ const (
 )
 
 var (
-	_ acceptor            = (*jsonAcceptor)(nil)
-	_ http.ResponseWriter = (*jsonAcceptor)(nil)
+	_ selectiveResponseWriter = (*jsonResponseWriter)(nil)
+	_ http.ResponseWriter     = (*jsonResponseWriter)(nil)
 )
 
-type jsonAcceptor struct {
+type jsonResponseWriter struct {
 	w       http.ResponseWriter
 	f       http.Flusher
 	encoder *json.Encoder
 	nd      bool
 }
 
-func newJsonAcceptor(w http.ResponseWriter) jsonAcceptor {
-	return jsonAcceptor{
+func newJsonResponseWriter(w http.ResponseWriter) jsonResponseWriter {
+	return jsonResponseWriter{
 		w:       w,
 		encoder: json.NewEncoder(w),
 	}
 }
 
-func (i *jsonAcceptor) Accept(r *http.Request) error {
+func (i *jsonResponseWriter) Accept(r *http.Request) error {
 	accepts := r.Header.Values("Accept")
 	var okJson bool
 	for _, accept := range accepts {
@@ -75,14 +75,14 @@ func (i *jsonAcceptor) Accept(r *http.Request) error {
 	return nil
 }
 
-func (i *jsonAcceptor) Header() http.Header {
+func (i *jsonResponseWriter) Header() http.Header {
 	return i.w.Header()
 }
 
-func (i *jsonAcceptor) Write(b []byte) (int, error) {
+func (i *jsonResponseWriter) Write(b []byte) (int, error) {
 	return i.w.Write(b)
 }
 
-func (i *jsonAcceptor) WriteHeader(code int) {
+func (i *jsonResponseWriter) WriteHeader(code int) {
 	i.w.WriteHeader(code)
 }


### PR DESCRIPTION
When results are being streamed back do not store the results in-memory at response writers.

Refactor response writer abstractions for better human readability.