### PR TITLE
Implement cascade param and HTTP `OPTIONS` handling

### DIFF
--- a/cmd/caskadht/main.go
+++ b/cmd/caskadht/main.go
@@ -28,6 +28,8 @@ func main() {
 	libp2pListenAddrs := flag.String("libp2pListenAddrs", "", "The comma separated libp2p host listen addrs. If unspecified the default listen addrs are used at ephemeral port.")
 	httpListenAddr := flag.String("httpListenAddr", "0.0.0.0:40080", "The caskadht HTTP server listen address.")
 	useAcceleratedDHT := flag.Bool("useAcceleratedDHT", true, "Weather to use accelerated DHT client when possible.")
+	ipniRequireQueryParam := flag.Bool("ipniRequireQueryParam", false, "Weather to require IPNI `cascade` query parameter with matching label in order to respond to HTTP lookup requests. Not required by default.")
+	ipniCascadeLabel := flag.String("ipniCascadeLabel", "ipfs-dht", "The IPNI cascade label associated to this instance.")
 	logLevel := flag.String("logLevel", "info", "The logging level. Only applied if GOLOG_LOG_LEVEL environment variable is unset.")
 	flag.Parse()
 
@@ -94,6 +96,8 @@ func main() {
 		caskadht.WithHost(h),
 		caskadht.WithHttpListenAddr(*httpListenAddr),
 		caskadht.WithUseAcceleratedDHT(*useAcceleratedDHT),
+		caskadht.WithIpniCascadeLabel(*ipniCascadeLabel),
+		caskadht.WithIpniRequireCascadeQueryParam(*ipniRequireQueryParam),
 	)
 	if err != nil {
 		logger.Fatalw("Failed to instantiate caskadht", "err", err)

--- a/options.go
+++ b/options.go
@@ -10,17 +10,22 @@ import (
 type (
 	Option  func(*options) error
 	options struct {
-		h              host.Host
-		httpListenAddr string
-		bootstrapPeers []peer.AddrInfo
-		useAccDHT      bool
+		h                            host.Host
+		httpListenAddr               string
+		bootstrapPeers               []peer.AddrInfo
+		useAccDHT                    bool
+		ipniCascadeLabel             string
+		httpAllowOrigin              string
+		ipniRequireCascadeQueryParam bool
 	}
 )
 
 func newOptions(o ...Option) (*options, error) {
 	opts := options{
-		httpListenAddr: "0.0.0.0:40080",
-		useAccDHT:      false,
+		httpListenAddr:   "0.0.0.0:40080",
+		useAccDHT:        false,
+		ipniCascadeLabel: "ipfs-dht",
+		httpAllowOrigin:  "*",
 	}
 	for _, apply := range o {
 		if err := apply(&opts); err != nil {
@@ -72,6 +77,30 @@ func WithBootstrapPeers(p ...peer.AddrInfo) Option {
 func WithUseAcceleratedDHT(b bool) Option {
 	return func(o *options) error {
 		o.useAccDHT = b
+		return nil
+	}
+}
+
+func WithIpniCascadeLabel(l string) Option {
+	return func(o *options) error {
+		o.ipniCascadeLabel = l
+		return nil
+	}
+}
+
+func WithHttpAllowOrigin(ao string) Option {
+	return func(o *options) error {
+		o.httpAllowOrigin = ao
+		return nil
+	}
+}
+
+// WithIpniRequireCascadeQueryParam sets whether the server should require IPNI cascade query
+// parameter with the matching label in order to respond to HTTP lookup requests.
+// See: WithIpniCascadeLabel
+func WithIpniRequireCascadeQueryParam(p bool) Option {
+	return func(o *options) error {
+		o.ipniRequireCascadeQueryParam = p
 		return nil
 	}
 }


### PR DESCRIPTION
Introduce config to set the IPNI cascade label with default of `ipfs-dht`, and optionally require `?cascade=<label>` on IPNI HTTP lookup APIs before responding with results. The rationale for making the query parameter check optional is to offer an easier out-of-the-box setup and demo.

Add handling for HTTP `OPTIONS` requests according to the IPNI specification. While at it, also handle such requests on HTTP delegated routing API.