### PR TITLE
Optionally prefer JSON over NDJSON on wildcard `Accept` headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,17 @@ $ go install github.com/ipni/caskadht/cmd/caskadht@latest
 $ caskadht 
 Usage of caskadht:
   -httpListenAddr string
-        The caskadht HTTP server listen address. (default "0.0.0.0:40080")
+        The caskadht HTTP server listen address in address:port format. (default "0.0.0.0:40080")
+  -httpResponsePreferJson
+        Whether to prefer responding with JSON instead of NDJSON when Accept header is set to "*/*".
+  -ipniCascadeLabel string
+        The IPNI cascade label associated to this instance. (default "ipfs-dht")
+  -ipniRequireQueryParam
+        Weather to require IPNI "cascade" query parameter with matching label in order to respond to HTTP lookup requests. Not required by default.
   -libp2pIdentityPath string
         The path to the marshalled libp2p host identity. If unspecified a random identity is generated.
   -libp2pListenAddrs string
-        The comma separated libp2p host listen addrs. If unspecified the default listen addrs are used at ephemeral port.
+        The comma separated libp2p host listen multiaddrs. If unspecified the default listen multiaddrs are used at ephemeral port.
   -logLevel string
         The logging level. Only applied if GOLOG_LOG_LEVEL environment variable is unset. (default "info")
   -useAcceleratedDHT

--- a/caskadht.go
+++ b/caskadht.go
@@ -113,7 +113,7 @@ func (c *Caskadht) handleMh(w http.ResponseWriter, r *http.Request) {
 func (c *Caskadht) handleMhSubtree(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
-		c.handleLookup(newIPNILookupResponseWriter(w, c.ipniCascadeLabel, c.ipniRequireCascadeQueryParam), r)
+		c.handleLookup(newIPNILookupResponseWriter(w, c.ipniCascadeLabel, c.ipniRequireCascadeQueryParam, c.httpResponsePreferJson), r)
 	case http.MethodOptions:
 		discardBody(r)
 		c.handleLookupOptions(w)
@@ -126,7 +126,7 @@ func (c *Caskadht) handleMhSubtree(w http.ResponseWriter, r *http.Request) {
 func (c *Caskadht) handleRoutingV1ProvidersSubtree(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
-		c.handleLookup(newDelegatedRoutingLookupResponseWriter(w), r)
+		c.handleLookup(newDelegatedRoutingLookupResponseWriter(w, c.httpResponsePreferJson), r)
 	case http.MethodOptions:
 		discardBody(r)
 		c.handleLookupOptions(w)

--- a/cmd/caskadht/main.go
+++ b/cmd/caskadht/main.go
@@ -25,10 +25,11 @@ const (
 
 func main() {
 	libp2pIdentityPath := flag.String("libp2pIdentityPath", "", "The path to the marshalled libp2p host identity. If unspecified a random identity is generated.")
-	libp2pListenAddrs := flag.String("libp2pListenAddrs", "", "The comma separated libp2p host listen addrs. If unspecified the default listen addrs are used at ephemeral port.")
-	httpListenAddr := flag.String("httpListenAddr", "0.0.0.0:40080", "The caskadht HTTP server listen address.")
+	libp2pListenAddrs := flag.String("libp2pListenAddrs", "", "The comma separated libp2p host listen multiaddrs. If unspecified the default listen multiaddrs are used at ephemeral port.")
+	httpListenAddr := flag.String("httpListenAddr", "0.0.0.0:40080", "The caskadht HTTP server listen address in address:port format.")
+	httpResponsePreferJson := flag.Bool("httpResponsePreferJson", false, `Whether to prefer responding with JSON instead of NDJSON when Accept header is set to "*/*".`)
 	useAcceleratedDHT := flag.Bool("useAcceleratedDHT", true, "Weather to use accelerated DHT client when possible.")
-	ipniRequireQueryParam := flag.Bool("ipniRequireQueryParam", false, "Weather to require IPNI `cascade` query parameter with matching label in order to respond to HTTP lookup requests. Not required by default.")
+	ipniRequireQueryParam := flag.Bool("ipniRequireQueryParam", false, `Weather to require IPNI "cascade" query parameter with matching label in order to respond to HTTP lookup requests. Not required by default.`)
 	ipniCascadeLabel := flag.String("ipniCascadeLabel", "ipfs-dht", "The IPNI cascade label associated to this instance.")
 	logLevel := flag.String("logLevel", "info", "The logging level. Only applied if GOLOG_LOG_LEVEL environment variable is unset.")
 	flag.Parse()
@@ -98,6 +99,7 @@ func main() {
 		caskadht.WithUseAcceleratedDHT(*useAcceleratedDHT),
 		caskadht.WithIpniCascadeLabel(*ipniCascadeLabel),
 		caskadht.WithIpniRequireCascadeQueryParam(*ipniRequireQueryParam),
+		caskadht.WithHttpResponsePreferJson(*httpResponsePreferJson),
 	)
 	if err != nil {
 		logger.Fatalw("Failed to instantiate caskadht", "err", err)

--- a/options.go
+++ b/options.go
@@ -12,10 +12,11 @@ type (
 	options struct {
 		h                            host.Host
 		httpListenAddr               string
+		httpAllowOrigin              string
+		httpResponsePreferJson       bool
 		bootstrapPeers               []peer.AddrInfo
 		useAccDHT                    bool
 		ipniCascadeLabel             string
-		httpAllowOrigin              string
 		ipniRequireCascadeQueryParam bool
 	}
 )
@@ -101,6 +102,16 @@ func WithHttpAllowOrigin(ao string) Option {
 func WithIpniRequireCascadeQueryParam(p bool) Option {
 	return func(o *options) error {
 		o.ipniRequireCascadeQueryParam = p
+		return nil
+	}
+}
+
+// WithHttpResponsePreferJson sets whether to prefer non-streaming json response over streaming
+// ndjosn when the Accept header uses `*/*` wildcard. By default, in such case ndjson streaming
+// response is preferred.
+func WithHttpResponsePreferJson(b bool) Option {
+	return func(o *options) error {
+		o.httpResponsePreferJson = b
 		return nil
 	}
 }

--- a/response_writer_dr.go
+++ b/response_writer_dr.go
@@ -36,9 +36,9 @@ type (
 	}
 )
 
-func newDelegatedRoutingLookupResponseWriter(w http.ResponseWriter) lookupResponseWriter {
+func newDelegatedRoutingLookupResponseWriter(w http.ResponseWriter, preferJson bool) lookupResponseWriter {
 	return &delegatedRoutingLookupResponseWriter{
-		jsonResponseWriter: newJsonResponseWriter(w),
+		jsonResponseWriter: newJsonResponseWriter(w, preferJson),
 	}
 }
 

--- a/response_writer_ipni.go
+++ b/response_writer_ipni.go
@@ -36,9 +36,9 @@ type (
 	}
 )
 
-func newIPNILookupResponseWriter(w http.ResponseWriter, cascadeLabel string, requireQueryParam bool) lookupResponseWriter {
+func newIPNILookupResponseWriter(w http.ResponseWriter, cascadeLabel string, requireQueryParam bool, preferJson bool) lookupResponseWriter {
 	return &ipniLookupResponseWriter{
-		jsonResponseWriter: newJsonResponseWriter(w),
+		jsonResponseWriter: newJsonResponseWriter(w, preferJson),
 		cascadeLabel:       cascadeLabel,
 		requireQueryParam:  requireQueryParam,
 	}
@@ -89,10 +89,10 @@ func (i *ipniLookupResponseWriter) WriteProviderRecord(provider providerRecord) 
 		if i.f != nil {
 			i.f.Flush()
 		}
-		i.count++
 	} else {
 		i.result.ProviderResults = append(i.result.ProviderResults, rec)
 	}
+	i.count++
 	return nil
 }
 

--- a/response_writer_json.go
+++ b/response_writer_json.go
@@ -18,16 +18,18 @@ var (
 )
 
 type jsonResponseWriter struct {
-	w       http.ResponseWriter
-	f       http.Flusher
-	encoder *json.Encoder
-	nd      bool
+	w          http.ResponseWriter
+	f          http.Flusher
+	encoder    *json.Encoder
+	nd         bool
+	preferJson bool
 }
 
-func newJsonResponseWriter(w http.ResponseWriter) jsonResponseWriter {
+func newJsonResponseWriter(w http.ResponseWriter, preferJson bool) jsonResponseWriter {
 	return jsonResponseWriter{
-		w:       w,
-		encoder: json.NewEncoder(w),
+		w:          w,
+		encoder:    json.NewEncoder(w),
+		preferJson: preferJson,
 	}
 }
 
@@ -46,7 +48,7 @@ func (i *jsonResponseWriter) Accept(r *http.Request) error {
 		case mediaTypeJson:
 			okJson = true
 		case mediaTypeAny:
-			i.nd = true
+			i.nd = !i.preferJson
 			okJson = true
 		}
 		if i.nd && okJson {


### PR DESCRIPTION
Provide an option to prefer non-streaming JSON response instead of streaming NDJSON when the request uses `*/*` `Accept` header, disabled by default. The rationale is to avoid breaking changes for services that expect JSON by default from `/multihash` endpoint.

Fix a bug where counter in IPNI response writer is not updated on non-streaming response.