### PR TITLE
Filter out non public Addrs by default

### DIFF
--- a/caskadht.go
+++ b/caskadht.go
@@ -14,6 +14,8 @@ import (
 	record "github.com/libp2p/go-libp2p-record"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/routing"
+	"github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
 	"github.com/multiformats/go-multicodec"
 	"github.com/multiformats/go-varint"
 )
@@ -182,6 +184,16 @@ LOOP:
 				}
 				provider.Addrs = found.Addrs
 			}
+
+			if !c.addrFilterDisabled {
+				provider.Addrs = multiaddr.FilterAddrs(provider.Addrs, manet.IsPublicAddr)
+			}
+
+			if len(provider.Addrs) == 0 {
+				logger.Debugw("Found no public addrs for peer ID; skipping provider", "id", provider.ID)
+				continue
+			}
+
 			if err := w.WriteProviderRecord(providerRecord{AddrInfo: provider}); err != nil {
 				logger.Errorw("Failed to encode provider record", "err", err)
 				break LOOP

--- a/options.go
+++ b/options.go
@@ -18,6 +18,7 @@ type (
 		useAccDHT                    bool
 		ipniCascadeLabel             string
 		ipniRequireCascadeQueryParam bool
+		addrFilterDisabled           bool
 	}
 )
 
@@ -112,6 +113,15 @@ func WithIpniRequireCascadeQueryParam(p bool) Option {
 func WithHttpResponsePreferJson(b bool) Option {
 	return func(o *options) error {
 		o.httpResponsePreferJson = b
+		return nil
+	}
+}
+
+// WithAddrFilterDisabled sets whether to filter unroutable and private addresses from the results.
+// By default such address are excluded from results.
+func WithAddrFilterDisabled(b bool) Option {
+	return func(o *options) error {
+		o.addrFilterDisabled = b
 		return nil
 	}
 }


### PR DESCRIPTION
Add option to filter out results with non-public IPs, enabled by default.