### PR TITLE
Add extra events to publish on release

### DIFF
--- a/.github/workflows/publish-ecr.yml
+++ b/.github/workflows/publish-ecr.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - published
+      - released
   push:
     branches:
       - main

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,9 +1,11 @@
 name: Publish
 
 on:
+  workflow_dispatch:
   release:
     types:
       - published
+      - released
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Unified CI now drafts releases which means `published` release is not triggering container publication. Add extra events to trigger tagged container release when release is made from a draft.