### PR TITLE
Find provider addresses asynchronously

### DIFF
--- a/attempt_cache.go
+++ b/attempt_cache.go
@@ -1,0 +1,41 @@
+package cascadht
+
+import (
+	"sync"
+	"time"
+
+	"github.com/golang/groupcache/lru"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type (
+	peerRoutingAttemptCache struct {
+		lock     sync.Mutex
+		lru      *lru.Cache
+		maxSince time.Duration
+	}
+	attempt struct {
+		at time.Time
+	}
+)
+
+func newPeerRoutingAttemptCache(maxEntries int, maxAge time.Duration) *peerRoutingAttemptCache {
+	return &peerRoutingAttemptCache{
+		lru:      lru.New(maxEntries),
+		maxSince: maxAge,
+	}
+}
+
+func (p *peerRoutingAttemptCache) attempt(id peer.ID) bool {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if v, found := p.lru.Get(id); found {
+		if latest, ok := v.(*attempt); ok && latest != nil {
+			if time.Since(latest.at) < p.maxSince {
+				return false
+			}
+		}
+	}
+	p.lru.Add(id, &attempt{at: time.Now()})
+	return true
+}

--- a/cmd/caskadht/main.go
+++ b/cmd/caskadht/main.go
@@ -33,6 +33,7 @@ func main() {
 	useResourceManager := flag.Bool("useResourceManager", true, "Weather to use resource manager with built-in increased limits. When disabled Resource Manager is completely disabled.")
 	ipniRequireQueryParam := flag.Bool("ipniRequireQueryParam", false, `Weather to require IPNI "cascade" query parameter with matching label in order to respond to HTTP lookup requests. Not required by default.`)
 	ipniCascadeLabel := flag.String("ipniCascadeLabel", "ipfs-dht", "The IPNI cascade label associated to this instance.")
+	findProvidersLimit := flag.Int("findProvidersLimit", 0, "The maximum number of provider records to find. Defaults to zero, i.e. no limit.")
 	logLevel := flag.String("logLevel", "info", "The logging level. Only applied if GOLOG_LOG_LEVEL environment variable is unset.")
 	flag.Parse()
 
@@ -106,6 +107,7 @@ func main() {
 		caskadht.WithIpniCascadeLabel(*ipniCascadeLabel),
 		caskadht.WithIpniRequireCascadeQueryParam(*ipniRequireQueryParam),
 		caskadht.WithHttpResponsePreferJson(*httpResponsePreferJson),
+		caskadht.WithFindProvidersLimit(*findProvidersLimit),
 	)
 	if err != nil {
 		logger.Fatalw("Failed to instantiate caskadht", "err", err)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ipni/caskadht
 go 1.19
 
 require (
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/ipfs/go-cid v0.3.2
 	github.com/ipfs/go-ipns v0.3.0
 	github.com/ipfs/go-log/v2 v2.5.1

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,9 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
-github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/options.go
+++ b/options.go
@@ -1,6 +1,8 @@
 package cascadht
 
 import (
+	"time"
+
 	"github.com/libp2p/go-libp2p"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -19,15 +21,20 @@ type (
 		ipniCascadeLabel             string
 		ipniRequireCascadeQueryParam bool
 		addrFilterDisabled           bool
+		findProvidersLimit           int
+		prAttemptCacheMaxSize        int
+		prAttemptCacheMaxAge         time.Duration
 	}
 )
 
 func newOptions(o ...Option) (*options, error) {
 	opts := options{
-		httpListenAddr:   "0.0.0.0:40080",
-		useAccDHT:        false,
-		ipniCascadeLabel: "ipfs-dht",
-		httpAllowOrigin:  "*",
+		httpListenAddr:        "0.0.0.0:40080",
+		useAccDHT:             false,
+		ipniCascadeLabel:      "ipfs-dht",
+		httpAllowOrigin:       "*",
+		prAttemptCacheMaxSize: 1024,
+		prAttemptCacheMaxAge:  20 * time.Minute,
 	}
 	for _, apply := range o {
 		if err := apply(&opts); err != nil {
@@ -123,6 +130,15 @@ func WithHttpResponsePreferJson(b bool) Option {
 func WithAddrFilterDisabled(b bool) Option {
 	return func(o *options) error {
 		o.addrFilterDisabled = b
+		return nil
+	}
+}
+
+// WithFindProvidersLimit sets the limit on number of providers to find.
+// Defaults to zero, i.e. no limit.
+func WithFindProvidersLimit(l int) Option {
+	return func(o *options) error {
+		o.findProvidersLimit = l
 		return nil
 	}
 }


### PR DESCRIPTION
Return the search results with addrs immediately and on background search for missing addrs of provider records such that:
* local peerstore is searched first for addrs
* rate of attempts for finding addrs is controlled by a cache with TTL mechanism
* any found addrs also update the peerstore.

Add option to limit the maximum number of providers returned in search with default to no limit.