### PR TITLE
fix: only send one newline after each record

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,8 @@ $ curl http://localhost:40080/multihash/QmfQJymEUXsGNzHMmpGYmUcFiAtGw2ia97EXNDVD
 < Transfer-Encoding: chunked
 < 
 {"ContextID":"aXBmcy1kaHQtY2FzY2FkZQ==","Metadata":"gBI=","Provider":{"ID":"12D3KooWSnniGsyAF663gvHdqhyfJMCjWJv54cGSzcPiEMAfanvU","Addrs":["/ip6/2604:1380:45f1:8400::1/tcp/4002/ws","/ip4/145.40.89.195/tcp/4002/ws","/ip6/2604:1380:45f1:8400::1/tcp/4001","/ip4/145.40.89.195/tcp/4001"]}}
-
 {"ContextID":"aXBmcy1kaHQtY2FzY2FkZQ==","Metadata":"gBI=","Provider":{"ID":"12D3KooWEDMw7oRqQkdCJbyeqS5mUmWGwTp8JJ2tjCzTkHboF6wK","Addrs":["/ip6/2604:1380:45e1:2700::3/tcp/4001","/ip6/2604:1380:45e1:2700::3/tcp/4002/ws","/ip4/139.178.68.91/tcp/4001","/ip4/139.178.68.91/tcp/4002/ws"]}}
-
 {"ContextID":"aXBmcy1kaHQtY2FzY2FkZQ==","Metadata":"gBI=","Provider":{"ID":"12D3KooWRgXWwnZQJgdW1GHW7hJ5UvZ8MLp7HBCSWS596PypAs8M","Addrs":["/ip4/147.75.49.91/tcp/4002/ws","/ip6/2604:1380:45e1:2700::b/tcp/4001","/ip6/2604:1380:45e1:2700::b/tcp/4002/ws","/ip4/147.75.49.91/tcp/4001"]}}
-
 * Operation timed out after 1005 milliseconds with 1890 bytes received
 * Closing connection 0
 curl: (28) Operation timed out after 1005 milliseconds with 1890 bytes received
@@ -106,13 +103,9 @@ $ curl  http://localhost:40080/routing/v1/providers/QmfQJymEUXsGNzHMmpGYmUcFiAtG
 < Transfer-Encoding: chunked
 < 
 {"Protocol":"transport-bitswap","Schema":"bitswap","ID":"12D3KooWHVXoJnv2ifmr9K6LWwJPXxkfvzZRHzjiTZMvybeTnwPy","Addrs":["/ip4/145.40.89.101/tcp/4001","/ip4/145.40.89.101/tcp/4002/ws","/ip4/145.40.89.101/udp/4001/quic","/ip6/2604:1380:45f1:d800::1/tcp/4001","/ip6/2604:1380:45f1:d800::1/tcp/4002/ws","/ip6/2604:1380:45f1:d800::1/udp/4001/quic"]}
-
 {"Protocol":"transport-bitswap","Schema":"bitswap","ID":"12D3KooWDpp7U7W9Q8feMZPPEpPP5FKXTUakLgnVLbavfjb9mzrT","Addrs":["/ip4/147.75.80.75/tcp/4001","/ip4/147.75.80.75/tcp/4002/ws","/ip4/147.75.80.75/udp/4001/quic","/ip6/2604:1380:4601:f600::5/tcp/4001","/ip6/2604:1380:4601:f600::5/tcp/4002/ws","/ip6/2604:1380:4601:f600::5/udp/4001/quic"]}
-
 {"Protocol":"transport-bitswap","Schema":"bitswap","ID":"12D3KooWCrBiagtZMzpZePCr1tfBbrZTh4BRQf7JurRqNMRi8YHF","Addrs":["/ip4/147.75.87.65/tcp/4001","/ip4/147.75.87.65/tcp/4002/ws","/ip4/147.75.87.65/udp/4001/quic","/ip6/2604:1380:4601:f600::1/tcp/4001","/ip6/2604:1380:4601:f600::1/tcp/4002/ws","/ip6/2604:1380:4601:f600::1/udp/4001/quic"]}
-
 {"Protocol":"transport-bitswap","Schema":"bitswap","ID":"12D3KooWRNijznEQoXrxBeNLb2TqbSFm8gG8jKtfEsbC1C9nPqce","Addrs":["/ip4/147.75.87.211/tcp/4001","/ip4/147.75.87.211/tcp/4002/ws","/ip4/147.75.87.211/udp/4001/quic","/ip6/2604:1380:4601:f600::3/tcp/4001","/ip6/2604:1380:4601:f600::3/tcp/4002/ws","/ip6/2604:1380:4601:f600::3/udp/4001/quic"]}
-
 * Operation timed out after 1001 milliseconds with 1378 bytes received
 * Closing connection 0
 curl: (28) Operation timed out after 1001 milliseconds with 1378 bytes received

--- a/caskadht.go
+++ b/caskadht.go
@@ -26,7 +26,6 @@ import (
 var (
 	logger = log.Logger("caskadht")
 
-	newline          = []byte("\n")
 	cascadeContextID = []byte("ipfs-dht-cascade")
 	cascadeMetadata  = varint.ToUvarint(uint64(multicodec.TransportBitswap))
 )

--- a/response_writer_dr.go
+++ b/response_writer_dr.go
@@ -72,10 +72,6 @@ func (d *delegatedRoutingLookupResponseWriter) WriteProviderRecord(provider prov
 			logger.Errorw("Failed to encode ndjson response", "err", err)
 			return err
 		}
-		if _, err := d.w.Write(newline); err != nil {
-			logger.Errorw("Failed to encode ndjson response", "err", err)
-			return err
-		}
 		if d.f != nil {
 			d.f.Flush()
 		}

--- a/response_writer_ipni.go
+++ b/response_writer_ipni.go
@@ -104,10 +104,6 @@ func (i *ipniLookupResponseWriter) WriteProviderRecord(provider providerRecord) 
 			logger.Errorw("Failed to encode ndjson response", "err", err)
 			return err
 		}
-		if _, err := i.w.Write(newline); err != nil {
-			logger.Errorw("Failed to encode ndjson response", "err", err)
-			return err
-		}
 		if i.f != nil {
 			i.f.Flush()
 		}


### PR DESCRIPTION
> Each Line is a Valid JSON Value - (http://ndjson.org/)

Right now there's empty lines.

`json.Encoder.Encode` already adds a newline after each record: https://pkg.go.dev/encoding/json#Encoder.Encode
